### PR TITLE
Fixes typos in mllib.Rmd

### DIFF
--- a/mllib.Rmd
+++ b/mllib.Rmd
@@ -156,7 +156,7 @@ As you can see, we can easily and effectively combine dplyr data transformation 
 
 ## Transformers
 
-A model is often fit not on a dataset as-is, but instead on some transformation of that dataset. Spark provides [feature transformers](http://spark.apache.org/docs/latest/ml-features.html), faciliating many common transformations of data within in a Spark DataFrame, and sparklyr exposes these within the `ft_*` family of functions. These routines generally take one or more input columns, and generate a new output column formed as a transformation of those columns.
+A model is often fit not on a dataset as-is, but instead on some transformation of that dataset. Spark provides [feature transformers](http://spark.apache.org/docs/latest/ml-features.html), faciliating many common transformations of data within a Spark DataFrame, and sparklyr exposes these within the `ft_*` family of functions. These routines generally take one or more input columns, and generate a new output column formed as a transformation of those columns.
 
 | Function | Description  |
 |----------------------------|---------------------------------------------|
@@ -228,7 +228,7 @@ Database: spark connection master=local app=sparklyr local=TRUE
 
 ## Examples
 
-We will use the `iris` data set to examine a handful of learning altogithms and transformers. The iris data set measures attributes for 150 flowers in 3 different species of iris.
+We will use the `iris` data set to examine a handful of learning algorithms and transformers. The iris data set measures attributes for 150 flowers in 3 different species of iris.
 
 ```{r}
 library(sparklyr)


### PR DESCRIPTION
I didn't fix this but I question the wording here: 

> Use Spark's K-means clustering to partition a data set into groups. 

I couldn't tell if Spark's K-mean function actually partitions the data the way that `sdf_partition()` does. If it does not, I think we should change the phrase to "sort a data set into groups" to avoid confusion.