### PR TITLE
updated Google Analytics tracking code to enable cross-domain tracking

### DIFF
--- a/config.toml
+++ b/config.toml
@@ -6,7 +6,7 @@ metadataformat = "yaml"
 pluralizeListTitles =   "false"
 ignoreFiles = ["\\.Rmd$", "_files$", "_cache$"]
 canonifyurls = true
-googleAnalytics = "UA-20375833-13"
+googleAnalytics = "UA-20375833-3"
 
 [params]
     description = "An R interface to Spark"


### PR DESCRIPTION
@danielfrg 
I’ve replaced your Google Analytics tracking number with the one for rstudio.com, which enables us to track users across domains.  Your site’s analytics will now be found under the rstudio.com property and I have built a filter and dashboard for you to view your site’s metrics separate from other domains.  Data will populate from today forward and you will need to visit your previous property for historical data.  Thank you for merging this pull request so that we can get a full picture of online user behavior.