### PR TITLE
Update extensions.qmd

### DIFF
--- a/guides/extensions.qmd
+++ b/guides/extensions.qmd
@@ -46,23 +46,24 @@ Here are links to some additional examples of extension packages:
 | Package | Description  |
 |----------------------------|---------------------------------------------|
 | [`spark.sas7bdat`](https://github.com/bnosac/spark.sas7bdat) | Read in SAS data in parallel into Apache Spark. |
-| [`rsparkling`](https://github.com/h2oai/rsparkling) | Extension for using [H2O](h2o.ai) machine learning algorithms against Spark Data Frames.  |
+| [`RSparkling`](https://github.com/h2oai/sparkling-water/tree/master/r) | Extension for using [H2O](h2o.ai) machine learning algorithms against Spark Data Frames.  |
 | [`sparkhello`](https://github.com/javierluraschi/sparkhello) | Simple example of including a custom JAR file within an extension package. |
 | [`rddlist`](https://github.com/clarkfitzg/rddlist) | Implements some methods of an R list as a Spark RDD (resilient distributed dataset). |
 | [`sparkwarc`](https://github.com/javierluraschi/sparkwarc) | Load [WARC files](http://commoncrawl.org/the-data/get-started/) into Apache Spark with sparklyr. |
 | [`sparkavro`](https://github.com/chezou/sparkavro) | Load Avro data into Spark with sparklyr. It is a wrapper of [spark-avro](https://github.com/databricks/spark-avro) |
 | [`crassy`](https://github.com/AkhilNairAmey/crassy) | Connect to Cassandra with sparklyr using the `Spark-Cassandra-Connector`. |
-| [`sparklygraphs`](https://github.com/kevinykuo/sparklygraphs) | R interface for [GraphFrames](https://graphframes.github.io/) which aims to provide the functionality of [GraphX](http://spark.apache.org/graphx/). |
+| [`graphframes`](https://github.com/rstudio/graphframes) | R interface for [GraphFrames](https://spark.rstudio.com/packages/graphframes/latest/) which aims to provide the functionality of [GraphX](http://spark.apache.org/graphx/). |
 | [`sparklyr.nested`](https://mitre.github.io/sparklyr.nested/) | Extension for working with nested data. |
 | [`sparklyudf`](https://github.com/javierluraschi/sparklyudf) | Simple example registering an Scala UDF within an extension package. |
 | [`mleap`](https://github.com/rstudio/mleap) | R Interface to MLeap. |
 | [`sparkbq`](https://github.com/miraisolutions/sparkbq) | Sparklyr extension package to connect to Google BigQuery. |
-| [`sparkgeo`](https://github.com/miraisolutions/sparkgeo) | Sparklyr extension package providing geospatial analytics capabilities. |
+| [`apache.sedona`](https://github.com/apache/sedona) |R interface to Apache Sedona (ex-GeoSpark) to perform spatial analysis in Spark. |
+| [`geospark`](https://github.com/harryprince/geospark) | R interface to GeoSpark to perform spatial analysis in Spark. |
+| [`sparkgeo`](https://github.com/miraisolutions/sparkgeo) | Sparklyr extension package providing geospatial analytics capabilities using Magellan. |
 | [`sparklytd`](https://github.com/chezou/sparklytd) | Spaklyr plugin for td-spark to connect TD from R. |
 | [`sparkts`](https://github.com/nathaneastwood/sparkts) | Extensions for the spark-timeseries framework. |
 | [`sparkxgb`](https://github.com/rstudio/sparkxgb) | R interface for XGBoost on Spark. |
 | [`sparktf`](https://github.com/rstudio/sparktf) | R interface to Spark TensorFlow Connector. |
-| [`geospark`](https://github.com/harryprince/geospark) | R interface to GeoSpark to perform spatial analysis in Spark. |
 | [`synapseml`](https://github.com/microsoft/SynapseML/blob/master/website/docs/reference/R-setup.md) | Simplifies the creation of scalable machine learning pipelines. SynapseML builds on Apache Spark and SparkML to enable new kinds of machine learning, analytics, and model deployment workflows. |
 
 ## Core Types


### PR DESCRIPTION
Updated names and links
Added apache.sedona
Grouped geo extensions together

I believe the reference to ensure_ functions is not valid anymore. I can remove the sentence below also.


> The [`ensure_*`](http://spark.rstudio.com/reference/sparklyr/latest/ensure.html) family of functions can be used to enforce specific data types that are passed to a Spark routine. For example, Spark routines that require an integer will not accept an R numeric element. Use these functions ensure certain parameters are scalar integers, or scalar doubles, and so on.
