### PR TITLE
Update Spark EC2 installation documentation

### DIFF
--- a/deployment/stand-alone-aws.qmd
+++ b/deployment/stand-alone-aws.qmd
@@ -19,7 +19,7 @@ The topology will look something like this:
 Here are the details of the EC2 instance, just deploy one at this point:
 
 -   **Type:** t2.medium
--   **OS:** Ubuntu 16.04 LTS
+-   **OS:** Ubuntu 22.04 LTS
 -   **Disk space:** At least 20GB
 -   **Security group:** Open the following ports: 8080 (Spark UI), 4040 (Spark Worker UI), 8088 (sparklyr UI) and 8787 (RStudio). Also open *All TCP* ports for the machines inside the security group.
 
@@ -51,9 +51,9 @@ to install Open JDK version 8.
 
 <!-- -->
 
-    wget http://d3kbcqa49mib13.cloudfront.net/spark-2.1.0-bin-hadoop2.7.tgz
-    tar -xvzf spark-2.1.0-bin-hadoop2.7.tgz
-    cd spark-2.1.0-bin-hadoop2.7
+    wget https://archive.apache.org/dist/spark/spark-3.5.5/spark-3.5.5-bin-hadoop3.tgz
+    tar -xvzf spark-3.5.5-bin-hadoop3.tgz
+    cd spark-3.5.5-bin-hadoop3
 
 ### Create and launch AMI
 
@@ -118,7 +118,7 @@ Select one of the nodes to execute this section. Please check the [RStudio downl
 
 <!-- -->
 
-    sudo spark-2.1.0-bin-hadoop2.7/sbin/start-master.sh
+    sudo spark-3.5.5-bin-hadoop3/sbin/start-master.sh
 
 -   Close the terminal connection (optional)
 
@@ -128,9 +128,9 @@ Select one of the nodes to execute this section. Please check the [RStudio downl
 
 <!-- -->
 
-    sudo spark-2.1.0-bin-hadoop2.7/sbin/start-slave.sh spark://[Master node's IP address]:7077
+    sudo spark-3.5.5-bin-hadoop3/sbin/start-slave.sh spark://[Master node's IP address]:7077
 
-*sudo spark-2.1.0-bin-hadoop2.7/sbin/start-slave.sh spark://ip-172-30-1-94.us-west-2.compute.internal:7077*
+*sudo spark-3.5.5-bin-hadoop3/sbin/start-slave.sh spark://ip-172-30-1-94.us-west-2.compute.internal:7077*
 
 -   Close the terminal connection (optional)
 


### PR DESCRIPTION
Upon recently attempting to follow this documentation, I was able to make the following adjustments and get spark working on Ubuntu 22 with the latest version of Spark. 

Referencing: https://github.com/rstudio/spark.rstudio.com/issues/172